### PR TITLE
#68844: fix issue with special characters in product name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Released]
 
+### Fixed
+- issue with special characters in product name in minicart (#68844)
+
 ## [2.3.0] - 2020-07-03
 ### Added
 - extra variables to mega-menu template (#68257)

--- a/Magento_Checkout/web/template/minicart/item/default.html
+++ b/Magento_Checkout/web/template/minicart/item/default.html
@@ -26,16 +26,15 @@
                             attr: {
                                 href: product_url,
                                 title: product_name
-                            }
+                            },
+                            html: product_name
                         "
                         class="
                             link
                             link--invert
                             minicart-product__link
                         "
-                    >
-                        <!-- ko text: product_name --><!-- /ko -->
-                    </a>
+                    ></a>
                 </h3>
                 <!-- ko ifnot: canApplyMsrp -->
                     <div


### PR DESCRIPTION
## Issue
With usage of html special cars in product name

## Before:
![](https://i.gyazo.com/ab74848a64622b0ba1b8a5a2db7e81cc.png)

## After:
![](https://i.gyazo.com/c82e65035817d58420707fa69a695fd2.png)