### PR TITLE
Fix gallery nav arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- issue with arrows looking wrong if gallery vertical/horizontal nav breakpoints are changed via configuration (#71113); Affects: gallery navigation
 - input and select styles in poduct gift card template (#70690); Affects: gift card PDP
 - review snippets (#69786)
 ### Added

--- a/Magento_Catalog/styles/modules/_fotorama.scss
+++ b/Magento_Catalog/styles/modules/_fotorama.scss
@@ -48,12 +48,15 @@
                         }
                     }
                 }
+            }
+        }
 
+        &--horizontal {
+            .fotorama__thumb__arr {
                 &--left,
                 &--right {
                     .fotorama__thumb--icon {
                         @extend .gallery__icon-arrow;
-                        @extend .gallery__icon-arrow--vertical;
 
                         position: relative;
                         height: 24px;
@@ -70,6 +73,24 @@
         &--vertical {
             .fotorama__nav__frame--thumb {
                 @extend .gallery__thumb--vertical;
+            }
+
+            .fotorama__thumb__arr {
+                &--left,
+                &--right {
+                    .fotorama__thumb--icon {
+                        @extend .gallery__icon-arrow;
+                        @extend .gallery__icon-arrow--vertical;
+
+                        position: relative;
+                        height: 24px;
+                        width: 24px;
+                        padding: 0;
+                        margin: auto;
+                        background-position: center;
+                        fill: $gallery__icon-arrow-color;
+                    }
+                }
             }
         }
 

--- a/Snowdog_Components/components/Organisms/gallery/_gallery.scss
+++ b/Snowdog_Components/components/Organisms/gallery/_gallery.scss
@@ -76,9 +76,7 @@
     &__icon-arrow {
         transform: translate3d(-50%, -50%, 0) rotate(-90deg);
         &--vertical {
-            @include mq($screen-l) {
-                transform: none;
-            }
+            transform: none;
         }
     }
 


### PR DESCRIPTION
Fix hardcoded breakpoints for horizontal/vertical nav arrows. 
If we change navigation breakpoint for gallery (horizontal/vertical) current styles will make in some cases arrow being "right/left" where it should be "top/bottom".

How to reproduce issue:
But can't be tested directly. To see issue change classes for 900px screen width from fotorama__nav-wrap--horizontal to fotorama__nav-wrap--vertical

https://i.gyazo.com/b2660d94e0223318ee12770dc12abad8.png