### PR TITLE
Fixed checkout summary subtotal typo

### DIFF
--- a/Magento_Tax/web/template/checkout/summary/subtotal.html
+++ b/Magento_Tax/web/template/checkout/summary/subtotal.html
@@ -21,7 +21,7 @@
             class="order-summary__value"
             data-bind="text: getValueInclTax()"
         />
-    </dliiv>
+    </li>
 <!-- /ko -->
 
 <!-- ko if: !isBothPricesDisplayed() && isIncludingTaxDisplayed() -->


### PR DESCRIPTION
Currently subtotal isn't displaying in checkout summary due to this typo.