### PR TITLE
Remove width property for email images

### DIFF
--- a/styles/email/_email-base-inline.scss
+++ b/styles/email/_email-base-inline.scss
@@ -32,7 +32,6 @@ body {
 
 img {
     height: auto;
-    width: auto;
 }
 
 table {

--- a/styles/email/_email-base-inline.scss
+++ b/styles/email/_email-base-inline.scss
@@ -32,7 +32,7 @@ body {
 
 img {
     height: auto;
-    width: 100%;
+    width: auto;
 }
 
 table {


### PR DESCRIPTION
Removes width property for email images to avoid stretched images, setting to `auto` will override e.g `width="180"` from logo so I think it's better to remove this property